### PR TITLE
[-] Removing tenant ref from companies

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -2,7 +2,7 @@ class Company < ApplicationRecord
   VALID_DOMAIN_REGEX = /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}\z/ix
 
   belongs_to :user
-  belongs_to :tenant, optional: true
+  # has_one :tenant, through: :users
   has_many :pages, dependent: :destroy
 
   validates :name, presence: true, length: { minimum: 3, maximum: 64 }

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -2,7 +2,6 @@ class Company < ApplicationRecord
   VALID_DOMAIN_REGEX = /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}\z/ix
 
   belongs_to :user
-  # has_one :tenant, through: :users
   has_many :pages, dependent: :destroy
 
   validates :name, presence: true, length: { minimum: 3, maximum: 64 }

--- a/db/migrate/20171225200830_remove_tenant_ref_from_companies.rb
+++ b/db/migrate/20171225200830_remove_tenant_ref_from_companies.rb
@@ -1,0 +1,5 @@
+class RemoveTenantRefFromCompanies < ActiveRecord::Migration[5.1]
+  def change
+    remove_reference :companies, :tenant, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171224131211) do
+ActiveRecord::Schema.define(version: 20171225200830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,8 +21,6 @@ ActiveRecord::Schema.define(version: 20171224131211) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
-    t.bigint "tenant_id"
-    t.index ["tenant_id"], name: "index_companies_on_tenant_id"
     t.index ["user_id"], name: "index_companies_on_user_id"
   end
 
@@ -73,7 +71,6 @@ ActiveRecord::Schema.define(version: 20171224131211) do
     t.index ["tenant_id"], name: "index_users_on_tenant_id"
   end
 
-  add_foreign_key "companies", "tenants"
   add_foreign_key "companies", "users"
   add_foreign_key "pages", "companies"
   add_foreign_key "users", "tenants"

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :company, class: Company do
-    tenant
     user
     name { Faker::Company.name }
     domain { Faker::Internet.domain_name }


### PR DESCRIPTION
Resolving a mistake in company model.
`Tenant has_many companies, through users` association
mistake was `company belongs_to tenant` in the company model