### PR TITLE
Added API key to profile view instead of user

### DIFF
--- a/app/controllers/account/tokens_controller.rb
+++ b/app/controllers/account/tokens_controller.rb
@@ -8,12 +8,12 @@ class Account::TokensController < ApplicationController
     else
       flash[:danger] = "Something went wrong, please contact support"
     end
-    redirect_to account_user_path(current_user)
+    redirect_to account_profile_path
   end
 
   def destroy
     current_user.deactivate_token
-    redirect_to account_user_path(current_user),
+    redirect_to account_profile_path,
                 flash: { info: "Your API key was successfully deactivated" }
   end
 end

--- a/app/views/account/profile/edit.html.slim
+++ b/app/views/account/profile/edit.html.slim
@@ -1,56 +1,60 @@
 - set_meta_tags title: "Edit - #{@profile.first_name} #{@profile.last_name} information",
         description: 'Edit user data'
-h1.col-md-6.col-md-offset-3 Edit Profile
-.row.breadcrumbs-top
-  .breadcrumb-wrapper.col-12
-    = render_breadcrumbs({ 'Dashboard' => account_root_path,
-                           'Profile' => account_profile_path,
-                           'Edit profile' => nil })
-= simple_form_for @profile, url: account_profile_path,
-                            defaults: { input_html: { class: 'form-control' } } do |f|
-  section.row
-    .col-sm-12
-      /! Overview
-      #overview.card
-        .card-header
-          h4.card-title Overview
-        .card-content
-          .card-body
-            .row
-              .card-image.col-sm-2
-                = image_tag(@profile.avatar, alt: "Avatar")
-              .card-text.col-sm-9
+.content-wrapper
+  .content-header.row
+    .content-header-left.col-md-6.col-12.mb-2
+      h3.content-header-title.mb-0 Edit Profile
+      .row.breadcrumbs-top
+        .breadcrumb-wrapper.col-12
+          = render_breadcrumbs({ 'Dashboard' => account_root_path,
+                                 'Profile' => account_profile_path,
+                                 'Edit profile' => nil })
+  .content-body
+    = simple_form_for @profile, url: account_profile_path,
+                                defaults: { input_html: { class: 'form-control' } } do |f|
+      section.row
+        .col-sm-12
+          /! Overview
+          #overview.card
+            .card-header
+              h4.card-title Overview
+            .card-content
+              .card-body
                 .row
-                  .col-sm-5
-                    = f.input :first_name
-                  .col-sm-5
-                    = f.input :last_name
-                = f.input :birthday, as: :date, start_year: 100.years.ago.year, end_year: 18.years.ago.year, order: [:day, :month, :year]
-                .row
-                  .col-sm-6
-                    = f.input :email, placeholder: 'user@domain.com'
-                  .col-sm-4
-                    = f.input :phone, label: 'Phone number', placeholder: 'No special characters.'
-      /! / Overview
-      /! Work & Education
-      .card
-        .card-header
-          h4.card-title Work & Education
-        .card-content.collapse.show
-          .card-body
-            .card-text
-              = f.input :work
-              = f.input :skills, label: 'Professional skills'
-              = f.input :education
-      /! / Work & Education
-      /! About
-      .card
-        .card-header
-          h4.card-title About
-        .card-content.collapse.show
-          .card-body
-            .card-text
-              = f.input :about, label: 'About you', placeholder: 'Write some details about yourself'
-      /! / About
-  = f.button :submit, 'Save Changes', class: "btn btn-primary"
+                  .card-image.col-sm-3
+                    = image_tag(@profile.avatar, alt: "Avatar")
+                  .card-text.col-sm-9
+                    .row
+                      .col-sm-5
+                        = f.input :first_name
+                      .col-sm-5
+                        = f.input :last_name
+                    = f.input :birthday, as: :date, start_year: 100.years.ago.year, end_year: 18.years.ago.year, order: [:day, :month, :year]
+                    .row
+                      .col-sm-6
+                        = f.input :email, placeholder: 'user@domain.com'
+                      .col-sm-4
+                        = f.input :phone, label: 'Phone number', placeholder: 'No special characters.'
+          /! / Overview
+          /! Work & Education
+          .card
+            .card-header
+              h4.card-title Work & Education
+            .card-content.collapse.show
+              .card-body
+                .card-text
+                  = f.input :work
+                  = f.input :skills, label: 'Professional skills'
+                  = f.input :education
+          /! / Work & Education
+          /! About
+          .card
+            .card-header
+              h4.card-title About
+            .card-content.collapse.show
+              .card-body
+                .card-text
+                  = f.input :about, label: 'About you', placeholder: 'Write some details about yourself'
+          /! / About
+      = f.button :submit, 'Save Changes', class: "btn btn-primary"
 

--- a/app/views/account/profile/show.html.slim
+++ b/app/views/account/profile/show.html.slim
@@ -58,11 +58,12 @@
                     - if @profile.auth_token?
                       .card-text.col-sm-4
                         = @profile.auth_token
-                    .card-text.col-sm-1
-                      .btn-group.btn-group-sm
-                        = link_to account_profile_tokens_path, method: :delete, class: 'btn btn-danger'
+                      .card-text.col-sm-1
+                        = link_to account_profile_tokens_path, method: :delete, class: 'btn btn-danger btn-sm'
                           i.fa.fa-minus
-                        = link_to account_profile_tokens_path, method: :post, class: 'btn btn-success'
+                    - else
+                      .card-text.col-sm-1
+                        = link_to account_profile_tokens_path, method: :post, class: 'btn btn-primary btn-sm'
                           i.fa.fa-plus
     .card
       - if @profile.work?

--- a/app/views/account/profile/show.html.slim
+++ b/app/views/account/profile/show.html.slim
@@ -10,9 +10,9 @@
           = render_breadcrumbs({ 'Dashboard' => account_root_path,
                                  'Profile' => nil })
     .content-header-right.text-md-right.col-md-6.col-12
-      = link_to edit_account_profile_path,
-                class: 'button btn-icon btn btn-grey-blue btn-danger-2 btn-round'
-        i.fa.fa-pencil-square-o
+      .btn-icon.btn.btn-white.btn-round
+        = link_to edit_account_profile_path do
+          i.fa.fa-pencil-square-o
   .content-body
     section.row
       .col-sm-12
@@ -22,7 +22,7 @@
           .card-content
             .card-body
               .row
-                .card-image.col-sm-2
+                .card-image.col-sm-3
                   = image_tag(@profile.avatar)
                 .card-text.col-sm-9
                   .row
@@ -52,6 +52,18 @@
                       h6 Role:
                     .card-text.col-sm-9
                       = @profile.role
+                  .row.my-2
+                    .card-text.col-sm-2
+                      h6 Your API key:
+                    - if @profile.auth_token?
+                      .card-text.col-sm-4
+                        = @profile.auth_token
+                    .card-text.col-sm-1
+                      .btn-group.btn-group-sm
+                        = link_to account_profile_tokens_path, method: :delete, class: 'btn btn-danger'
+                          i.fa.fa-minus
+                        = link_to account_profile_tokens_path, method: :post, class: 'btn btn-success'
+                          i.fa.fa-plus
     .card
       - if @profile.work?
         .card-header

--- a/app/views/account/users/show.html.slim
+++ b/app/views/account/users/show.html.slim
@@ -12,13 +12,13 @@
                                  @user.full_name => nil })
     .content-header-right.text-md-right.col-md-6.col-12
       .form-group
-        = link_to edit_account_user_path,
-                class: 'button btn-icon btn btn-grey-blue btn-danger-2 btn-round'
-          i.fa.fa-pencil-square-o
-        = link_to account_user_path, method: :delete,
-                  data: {confirm: 'Are you certain you want to delete this user?'},
-                  class: 'button btn-icon btn btn-grey-blue btn-darker-2 btn-round'
-          i.fa.fa-trash-o
+        .btn-icon.btn.btn-white.btn-round
+          = link_to edit_account_user_path
+            i.fa.fa-pencil-square-o
+        .btn-icon.btn.btn-white.btn-round
+          = link_to account_user_path, method: :delete,
+                    data: {confirm: 'Are you certain you want to delete this user?'}
+            i.fa.fa-trash-o
   .content-body
     section.row
       .col-sm-12
@@ -56,17 +56,6 @@
                       h6 Tenant:
                     .card-text.col-sm-10
                       = @user.tenant_name
-              .row.my-2
-                .card-text.col-sm-2
-                  h6 Your API key:
-                .card-text.col-sm-4
-                  = @user.auth_token
-                .card-text.col-sm-1
-                  .btn-group.btn-group-sm
-                    = link_to account_tokens_path, method: :delete, class: 'btn btn-danger'
-                      i.fa.fa-minus
-                    = link_to account_tokens_path, method: :post, class: 'btn btn-success'
-                      i.fa.fa-plus
         .card
           .card-header
             h4.card-title

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -14,8 +14,8 @@ footer.footer.footer-light.navbar-shadow.py-5.ftr-height
             span.float-md-left.d-block.d-md-inline-block
               | Copyright ©
               = Date.today.year
-              a.text-bold-800.grey.darken-2[href="https://softserveinc.com/en-us/" target="_blank"]
-                |  SoftServe
+              a.text-bold-800.grey.darken-2[href="https://github.com/Ruby-IF081/heroes_team_app" target="_blank"]
+                |  Heroes Team
               | , All rights reserved.
       .col-md-6
         .row

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,7 @@ html
       .app-content.container.center-layout
         .row.alert
           - flash.each do |message_type, message|
-            = content_tag(:div, message, class: "alert alert-#{message_type} col-md-3")
+            = content_tag(:div, message, class: "alert alert-#{message_type}")
         = yield
     = any_login_here if defined?(AnyLogin)
     = render 'layouts/footer'

--- a/app/views/layouts/shared/_user_menu.html.slim
+++ b/app/views/layouts/shared/_user_menu.html.slim
@@ -1,7 +1,6 @@
 ul.nav.navbar-nav.float-right
   li.dropdown.dropdown-user.nav-item
-    = link_to account_user_path(current_user), { class: 'dropdown-toggle nav-link dropdown-user-link',
-                                                    'data-toggle' => 'dropdown' } do
+    = link_to account_profile_path, { class: 'dropdown-toggle nav-link dropdown-user-link' } do
       span.avatar.avatar-online
         = gravatar_image_tag(current_user.email)
         i

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,6 @@ Rails.application.routes.draw do
   }
 
   namespace :account do
-    resource :tokens, only: %i[create destroy]
     root 'dashboard#index'
     resources    :companies do
       resources  :pages, only: %i[show index] do
@@ -28,8 +27,10 @@ Rails.application.routes.draw do
     resources :comments,           only: %i[create destroy]
     resources :tenants,            only: %i[show index]
     resource  :my_tenant,          only: %i[show edit update]
-    resource  :profile,            only: %i[show edit update], controller: 'profile'
     resources :analytics,          only: %i[index]
+    resource  :profile,            only: %i[show edit update], controller: 'profile' do
+      resource :tokens, only: %i[create destroy]
+    end
     resources :users do
       member do
         post :impersonate

--- a/spec/controllers/account/tokens_controller_spec.rb
+++ b/spec/controllers/account/tokens_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Account::TokensController, type: :controller do
       post :create
 
       expect(response).to have_http_status(302)
-      expect(response).to redirect_to(account_user_path(user))
+      expect(response).to redirect_to(account_profile_path)
       expect(controller).to set_flash[:success]
     end
   end
@@ -37,7 +37,7 @@ RSpec.describe Account::TokensController, type: :controller do
       delete :destroy
 
       expect(response).to have_http_status(302)
-      expect(response).to redirect_to(account_user_path(user))
+      expect(response).to redirect_to(account_profile_path)
       expect(controller).to set_flash[:info]
     end
   end


### PR DESCRIPTION
As was suggested before
`igorkasyanchuk 
move to "profile" as member methods. But keep this controller.
basically I want to have routes like
/account/profile/generate_token
/account/profile/deactivate_token`
made token controller as member for profile
minor view changes:
making buttons white to suite the theme...


**CHECK LIST**
- [ ] specs added
- [x] specs passed
- [x] code coverage >90%
- [ ] DB indexes added if needed
- [ ] seed.rb file is updated if needed
- [x] PR is reviewed manually again (to make sure you have 100% ready code)
- [x] PR doesn't have conflicts with main branch
- [ ] I've checked new feature as logged in and logged out user if needed
- [ ] "let!" is used in specs
- [ ] screenshot of rails_best_practices and other tools added
- [x] screenshot of feature is added if task has UI

![image](https://user-images.githubusercontent.com/23340152/35647994-fe2f4cfe-06dc-11e8-88b8-554b4c49b298.png)
